### PR TITLE
added fix for nginx CSRFPolicy

### DIFF
--- a/alfinstall.sh
+++ b/alfinstall.sh
@@ -186,7 +186,7 @@ EOF
   sudo curl -# -o /etc/nginx/nginx.conf $BASE_DOWNLOAD/nginx/nginx.conf
   sudo mkdir -p /var/cache/nginx/alfresco
   sudo chown -R www-data:root /var/cache/nginx/alfresco
-  if [ "$installtomcat" = "y" ]; 
+  if [ "$installtomcat" = "y" ]; then
     read -e -p "Please enter the host's fully qualified domain name${ques} [`hostname`] " -i "`hostname`" HOSTNAME
     SHARE_SECURITY=$ALF_HOME/tomcat/webapps/share/WEB-INF/classes/alfresco/share-security-config.xml
     sudo cp $SHARE_SECURITY $SHARE_SECURITY.backup


### PR DESCRIPTION
When using the nginx proxy, it will fail with "Possible CSRF attack noted when asserting referer header" while trying to login, logged in share.log. This pull request makes the necessary changes to the share-security-config.xml to allow forwarded requests from nginx. 
