### PR TITLE
remove LibreOffice desktop integration

### DIFF
--- a/alfinstall.sh
+++ b/alfinstall.sh
@@ -362,6 +362,9 @@ if [ "$installibreoffice" = "y" ]; then
   tar xf LibreOffice*.tar.gz
   cd "$(find . -type d -name "LibreOffice*")"
   cd DEBS
+  rm *gnome-integration*.deb &&\
+  rm *kde-integration*.deb &&\
+  rm *debian-menus*.deb &&\
   sudo dpkg -i *.deb
   echo
   echoblue "Installing some support fonts for better transformations."


### PR DESCRIPTION
When run in Headless mode, the packages related with gnome, kde or debian-menus are useless, and trigger 100% CPU usage. The easiest workaround is not installing these packages.