### PR TITLE
Duplicate MIME type "text/html"

### DIFF
--- a/nginx/basic-settings.conf
+++ b/nginx/basic-settings.conf
@@ -30,6 +30,6 @@
 	gzip_min_length		1400;
 	gzip_buffers        16 8k;
 	gzip_proxied		any;
-	gzip_types          text/html text/xml text/plain text/css text/csv text/x-markdown text/x-web-markdown application/json text/javascript application/javascript application/x-javascript application/xhtml+xml application/atom+xml application/rss+xml application/atomsvc+xml;
+	gzip_types          text/xml text/plain text/css text/csv text/x-markdown text/x-web-markdown application/json text/javascript application/javascript application/x-javascript application/xhtml+xml application/atom+xml application/rss+xml application/atomsvc+xml;
 	#gzip_vary          on;
     


### PR DESCRIPTION
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/conf.d/basic-settings.conf:33